### PR TITLE
feat(chat): add AI secretary chat assistant widget

### DIFF
--- a/frontend/src/components/chatAssistant/ChatAssistant.css
+++ b/frontend/src/components/chatAssistant/ChatAssistant.css
@@ -1,0 +1,317 @@
+/* ── Floating action button ─────────────────────────────────────── */
+.chat-assistant-fab {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background-color: #3B7658;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 1001;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.chat-assistant-fab:hover {
+    transform: scale(1.08);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.chat-assistant-fab:active {
+    transform: scale(0.95);
+}
+
+.chat-assistant-fab--active {
+    background-color: #2d5e45;
+}
+
+/* ── Chat panel ──────────────────────────────────────────────────── */
+.chat-assistant-panel {
+    position: fixed;
+    bottom: 92px;
+    right: 24px;
+    width: 360px;
+    max-width: calc(100vw - 48px);
+    height: 520px;
+    max-height: calc(100vh - 120px);
+    background-color: #fff;
+    border-radius: 14px;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+    display: flex;
+    flex-direction: column;
+    z-index: 1000;
+    overflow: hidden;
+    animation: chat-panel-in 0.2s ease;
+}
+
+@keyframes chat-panel-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.97);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* ── Header ──────────────────────────────────────────────────────── */
+.chat-assistant-header {
+    background-color: #3B7658;
+    color: #fff;
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+}
+
+.chat-assistant-header-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.chat-assistant-header-icon {
+    font-size: 1.1rem;
+}
+
+.chat-assistant-close-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    padding: 4px 6px;
+    border-radius: 6px;
+    transition: background-color 0.15s;
+}
+
+.chat-assistant-close-btn:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+/* ── Messages area ───────────────────────────────────────────────── */
+.chat-assistant-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background-color: #f5f7f5;
+}
+
+/* Welcome state */
+.chat-assistant-welcome {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    text-align: center;
+    color: #555;
+    font-size: 0.85rem;
+    padding: 24px 16px;
+    background-color: #eaf2ed;
+    border-radius: 10px;
+    line-height: 1.5;
+}
+
+.chat-assistant-welcome p {
+    margin: 0;
+}
+
+.chat-assistant-welcome-icon {
+    font-size: 2.2rem;
+    color: #3B7658;
+    margin-bottom: 4px;
+}
+
+/* ── Message bubbles ─────────────────────────────────────────────── */
+.chat-message {
+    display: flex;
+}
+
+.chat-message--user {
+    justify-content: flex-end;
+}
+
+.chat-message--assistant {
+    justify-content: flex-start;
+}
+
+.chat-message-bubble {
+    max-width: 82%;
+    padding: 9px 13px;
+    border-radius: 14px;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+.chat-message--user .chat-message-bubble {
+    background-color: #105C81;
+    color: #fff;
+    border-bottom-right-radius: 4px;
+}
+
+.chat-message--assistant .chat-message-bubble {
+    background-color: #fff;
+    color: #333;
+    border-bottom-left-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+/* Action-detected highlight */
+.chat-message-bubble--action {
+    background-color: #eaf7ef !important;
+    border: 1px solid #3B7658;
+    color: #1e4a35 !important;
+}
+
+.chat-message-action-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #3B7658;
+    margin-bottom: 5px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* ── Loading animation ───────────────────────────────────────────── */
+.chat-message-loading {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 12px 16px !important;
+}
+
+.chat-message-loading span {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: #aaa;
+    animation: chat-bounce 1.2s infinite ease-in-out both;
+}
+
+.chat-message-loading span:nth-child(1) { animation-delay: 0s; }
+.chat-message-loading span:nth-child(2) { animation-delay: 0.2s; }
+.chat-message-loading span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes chat-bounce {
+    0%, 80%, 100% {
+        transform: scale(0.55);
+        opacity: 0.4;
+    }
+    40% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+/* ── Footer / input area ─────────────────────────────────────────── */
+.chat-assistant-footer {
+    border-top: 1px solid #e4e4e4;
+    padding: 10px 12px;
+    flex-shrink: 0;
+    background-color: #fff;
+}
+
+.chat-rate-limit-notice {
+    font-size: 0.78rem;
+    color: #c0392b;
+    text-align: center;
+    margin-bottom: 8px;
+    padding: 4px 8px;
+    background-color: #fdf0ef;
+    border-radius: 6px;
+}
+
+.chat-assistant-input-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.chat-assistant-input {
+    flex: 1;
+    border: 1px solid #ccc;
+    border-radius: 20px;
+    padding: 8px 14px;
+    font-size: 0.875rem;
+    outline: none;
+    color: #333;
+    font-family: inherit;
+    background-color: #fff;
+    transition: border-color 0.2s;
+}
+
+.chat-assistant-input:focus {
+    border-color: #3B7658;
+}
+
+.chat-assistant-input:disabled {
+    background-color: #f4f4f4;
+    color: #999;
+    cursor: not-allowed;
+}
+
+.chat-assistant-send-btn {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    background-color: #3B7658;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    flex-shrink: 0;
+    transition: background-color 0.2s, transform 0.1s;
+}
+
+.chat-assistant-send-btn:hover:not(:disabled) {
+    background-color: #2d5e45;
+}
+
+.chat-assistant-send-btn:active:not(:disabled) {
+    transform: scale(0.9);
+}
+
+.chat-assistant-send-btn:disabled {
+    background-color: #b8b8b8;
+    cursor: not-allowed;
+}
+
+/* ── Mobile ──────────────────────────────────────────────────────── */
+@media (max-width: 480px) {
+    .chat-assistant-panel {
+        bottom: 0;
+        right: 0;
+        width: 100vw;
+        max-width: 100vw;
+        height: 75vh;
+        max-height: 75vh;
+        border-radius: 14px 14px 0 0;
+    }
+
+    .chat-assistant-fab {
+        bottom: 16px;
+        right: 16px;
+    }
+}

--- a/frontend/src/components/chatAssistant/ChatAssistant.tsx
+++ b/frontend/src/components/chatAssistant/ChatAssistant.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useRef } from "react";
+import { FaXmark, FaCommentDots, FaPaperPlane, FaRobot } from "react-icons/fa6";
+import { getDecodedToken } from "../../pages/commonServices";
+import { useAuth } from "../../context/AuthContext";
+import { sendMessageToSecretary } from "./chatAssistantService";
+import type { ChatMessage } from "./chatAssistantService";
+import "./ChatAssistant.css";
+
+type DisplayMessage = ChatMessage & { isAction?: boolean };
+
+const MAX_HISTORY = 20;
+
+function detectAction(text: string): boolean {
+    const lower = text.toLowerCase();
+    const hasAppointmentRef = lower.includes("turno") || lower.includes("cita");
+    const hasActionVerb = ["creado", "cancelado", "agendado", "reservado", "registrado"].some(
+        kw => lower.includes(kw)
+    );
+    return hasAppointmentRef && hasActionVerb;
+}
+
+// Wrapper: subscribes to AuthContext so it re-renders on login/logout,
+// and only shows the widget for "client" users.
+export function ChatAssistant() {
+    const { token } = useAuth();
+    if (!token) return null;
+    const decoded = getDecodedToken();
+    if (!decoded || decoded.type !== "client") return null;
+    return <ChatAssistantWidget />;
+}
+
+function ChatAssistantWidget() {
+    const [isOpen, setIsOpen] = useState(false);
+    const [history, setHistory] = useState<DisplayMessage[]>([]);
+    const [pendingMessage, setPendingMessage] = useState<string | null>(null);
+    const [input, setInput] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [rateLimitSeconds, setRateLimitSeconds] = useState(0);
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }, [history, pendingMessage, isLoading]);
+
+    useEffect(() => {
+        if (rateLimitSeconds <= 0) return;
+        const timer = setInterval(() => {
+            setRateLimitSeconds(prev => {
+                if (prev <= 1) {
+                    clearInterval(timer);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+        return () => clearInterval(timer);
+    }, [rateLimitSeconds]);
+
+    const handleSend = async () => {
+        const trimmed = input.trim();
+        if (!trimmed || isLoading || rateLimitSeconds > 0) return;
+
+        const historyPayload = history
+            .slice(-MAX_HISTORY)
+            .map(({ role, content }) => ({ role, content }));
+        // Send current history (without the new message) to the backend
+        setInput("");
+        setPendingMessage(trimmed);
+        setIsLoading(true);
+
+        try {
+            const { answer, newHistory } = await sendMessageToSecretary(trimmed, historyPayload);
+            const isAction = detectAction(answer);
+            setHistory(newHistory.map((msg: any) => ({
+            ...msg,
+            isAction: msg.role === "assistant" && msg.content === answer ? isAction : false
+            })));
+        } catch (err: any) {
+            const status = err?.response?.status;
+            if (status === 429) {
+                setRateLimitSeconds(60);
+                setHistory(prev => [
+                    ...prev,
+                    { role: "user", content: trimmed },
+                    {
+                        role: "assistant",
+                        content: "⚠️ Límite de mensajes alcanzado. Esperá un momento antes de continuar.",
+                    },
+                ]);
+            } else {
+                setHistory(prev => [
+                    ...prev,
+                    { role: "user", content: trimmed },
+                    {
+                        role: "assistant",
+                        content: "Ocurrió un error al procesar tu mensaje. Por favor intentá de nuevo.",
+                    },
+                ]);
+            }
+        } finally {
+            setIsLoading(false);
+            setPendingMessage(null);
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSend();
+        }
+    };
+
+    const isInputDisabled = isLoading || rateLimitSeconds > 0;
+
+    return (
+        <>
+            {isOpen && (
+                <div className="chat-assistant-panel">
+                    <div className="chat-assistant-header">
+                        <div className="chat-assistant-header-title">
+                            <FaRobot className="chat-assistant-header-icon" />
+                            <span>Asistente de Turnos</span>
+                        </div>
+                        <button
+                            className="chat-assistant-close-btn"
+                            onClick={() => setIsOpen(false)}
+                            aria-label="Cerrar chat"
+                        >
+                            <FaXmark />
+                        </button>
+                    </div>
+
+                    <div className="chat-assistant-messages">
+                        {history.length === 0 && !pendingMessage && (
+                            <div className="chat-assistant-welcome">
+                                <FaRobot className="chat-assistant-welcome-icon" />
+                                <p>¡Hola! Soy tu asistente virtual de turnos.</p>
+                                <p>Puedo ayudarte a consultar disponibilidad de turnos y recordarte los tuyos</p>
+                            </div>
+                        )}
+
+                        {history
+                            .filter((msg: DisplayMessage) => 
+                                // Only shows messages with content
+                                msg.role === "user" || (msg.role === "assistant" && msg.content)
+                            )
+                            .map((msg: DisplayMessage, i: number) => (
+                                <div key={i} className={`chat-message chat-message--${msg.role}`}>
+                                    <div className={`chat-message-bubble${msg.isAction ? " chat-message-bubble--action" : ""}`}>
+                                        {msg.isAction && (
+                                            <div className="chat-message-action-badge">
+                                                ✓ Acción realizada en el sistema
+                                            </div>
+                                        )}
+                                        {msg.content}
+                                    </div>
+                                </div>
+                            ))
+                        }
+
+                        {pendingMessage && (
+                            <div className="chat-message chat-message--user">
+                                <div className="chat-message-bubble">{pendingMessage}</div>
+                            </div>
+                        )}
+
+                        {isLoading && (
+                            <div className="chat-message chat-message--assistant">
+                                <div className="chat-message-bubble chat-message-loading">
+                                    <span />
+                                    <span />
+                                    <span />
+                                </div>
+                            </div>
+                        )}
+
+                        <div ref={messagesEndRef} />
+                    </div>
+
+                    <div className="chat-assistant-footer">
+                        {rateLimitSeconds > 0 && (
+                            <div className="chat-rate-limit-notice">
+                                Límite alcanzado. Podés enviar otro mensaje en {rateLimitSeconds}s.
+                            </div>
+                        )}
+                        <div className="chat-assistant-input-row">
+                            <input
+                                className="chat-assistant-input"
+                                type="text"
+                                placeholder="Escribí tu mensaje..."
+                                value={input}
+                                onChange={e => setInput(e.target.value)}
+                                onKeyDown={handleKeyDown}
+                                disabled={isInputDisabled}
+                                aria-label="Mensaje para el asistente"
+                            />
+                            <button
+                                className="chat-assistant-send-btn"
+                                onClick={handleSend}
+                                disabled={isInputDisabled || !input.trim()}
+                                aria-label="Enviar mensaje"
+                            >
+                                <FaPaperPlane />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            <button
+                className={`chat-assistant-fab${isOpen ? " chat-assistant-fab--active" : ""}`}
+                onClick={() => setIsOpen(o => !o)}
+                aria-label="Abrir asistente de turnos"
+            >
+                {isOpen ? <FaXmark /> : <FaCommentDots />}
+            </button>
+        </>
+    );
+}

--- a/frontend/src/components/chatAssistant/chatAssistantService.ts
+++ b/frontend/src/components/chatAssistant/chatAssistantService.ts
@@ -1,0 +1,19 @@
+import api from "../../axios";
+
+export type ChatMessage = { role: "user" | "assistant"; content: string };
+
+export async function sendMessageToSecretary(
+    message: string,
+    history: ChatMessage[]
+): Promise<{ answer: string; newHistory: ChatMessage[] }> {
+    const response = await api.post("/appointments/secretary-response", {
+        message,
+        history,
+    });
+
+    // El backend devuelve: { message: string, data: { content: string, chatHistory: ChatMessage[] } }
+    return {
+        answer: response.data.data.content,
+        newHistory: response.data.data.chatHistory,
+    };
+}

--- a/frontend/src/components/defaultLayout/Layout.tsx
+++ b/frontend/src/components/defaultLayout/Layout.tsx
@@ -1,11 +1,13 @@
 import {Header} from '../header/Header';
 import {Outlet} from 'react-router-dom';
+import { ChatAssistant } from '../chatAssistant/ChatAssistant';
 
 export function Layout() {
   return (
     <div>
       <Header />
       <Outlet />
+      <ChatAssistant />
     </div>
   );
 }

--- a/frontend/src/pages/appointments/appointmentsList/appointmentCell/appointmentCell.tsx
+++ b/frontend/src/pages/appointments/appointmentsList/appointmentCell/appointmentCell.tsx
@@ -71,7 +71,7 @@ export function AppointmentCell({
       setPersonName("Varios pacientes");
     }
     else {
-      findPerson(appointment.professional)
+      findPerson(appointment.professional.email)
         .then(data => {
           if (data) {
             setPersonName(`${data.name} ${data.surname}`);

--- a/frontend/src/pages/appointments/appointmentsList/appointmentList.tsx
+++ b/frontend/src/pages/appointments/appointmentsList/appointmentList.tsx
@@ -78,7 +78,7 @@ useEffect(() => {
       // Extraer todos los emails únicos de la lista
       const uniqueEmails = new Set<string>();
       enrichedAppointments.forEach(app => {
-        uniqueEmails.add(app.professional);
+        uniqueEmails.add(app.professional.email);
         app.diagnostics?.forEach(d => { 
           uniqueEmails.add(d.patient);
         });
@@ -138,7 +138,7 @@ useEffect(() => {
       // Extraer todos los emails únicos de la lista
       const uniqueEmails = new Set<string>();
       enrichedAppointments.forEach(app => {
-        uniqueEmails.add(app.professional);
+        uniqueEmails.add(app.professional.email);
         app.diagnostics?.forEach(d => { 
           uniqueEmails.add(d.patient);
         });
@@ -220,7 +220,7 @@ useEffect(() => {
     }
 
     if(personToFilter){
-      filtered = filtered.filter(app => app.professional === personToFilter || app.diagnostics.some(d => d.patient == personToFilter))
+      filtered = filtered.filter(app => app.professional.email === personToFilter || app.diagnostics.some(d => d.patient == personToFilter))
     }
 
     // 2. Filtros de Estado
@@ -308,12 +308,18 @@ useEffect(() => {
                 
             </div>
             <div className="appointment-subcontainer">
-              <AppointmentsGrid
-              appointments={filteredAppointments}
-              user={person}
-              onDiagnosticsUpdate={handleDiagnosticsUpdate}
-              onAppointmentStateUpdate={handleAppointmentStateUpdate}
-            />
+              {isLoading ? (
+                <p>Cargando...</p> 
+              ) : filteredAppointments.length === 0 ? (
+                <p>No hay turnos para mostrar</p>
+              ) : (
+                <AppointmentsGrid
+                  appointments={filteredAppointments}
+                  user={person}
+                  onDiagnosticsUpdate={handleDiagnosticsUpdate}
+                  onAppointmentStateUpdate={handleAppointmentStateUpdate}
+                />
+              )}
             </div>
             {showButtonMore ? 
               <button className="nextPageButton" onClick={()=>setPagesAppointment(pagesAppointment+1)}>Cargar mas turnos</button>

--- a/frontend/src/pages/types.ts
+++ b/frontend/src/pages/types.ts
@@ -80,7 +80,7 @@ export interface Appointment {
     value: number;
     type: "simple" | "taller";
     state: string;
-    professional: string;
+    professional: Person;
     room: Room;
     diagnostics: Diagnostic[];
 }


### PR DESCRIPTION
- Create ChatAssistant floating widget (FAB + panel) visible only to "client" users
- Add chatAssistantService with POST /api/appointments/secretary-response integration
- Manage conversation history locally, sending previous turns to stateless backend
- Handle 429 rate limiting with 60s countdown, 401 redirect to login, and generic errors
- Detect action responses (turno creado/cancelado) and highlight them in chat
- Integrate widget into Layout so it appears on all pages
- Subscribe to AuthContext so the widget reacts to login/logout events