### PR TITLE
fix(bot): filter speciality client-side and suppress reasoning output

### DIFF
--- a/backend/src/appointments/appointments.service.ts
+++ b/backend/src/appointments/appointments.service.ts
@@ -672,7 +672,7 @@ export class AppointmentService {
         return await this.officeService.findAllActiveOffices();
 
       case "get_professionals":
-        return await this.peopleService.findProfessionalsWithOffices(args.officeId, args.speciality);
+        return await this.peopleService.findProfessionalsWithOffices(args.officeId);
 
       case "get_available_appointments":
         return await this.getAvailableAppointmensForPatient(args.officeId, args.professionalEmail, patientEmail);

--- a/backend/src/appointments/secretary.tools.ts
+++ b/backend/src/appointments/secretary.tools.ts
@@ -18,17 +18,13 @@ export const SECRETARY_TOOLS: Groq.Chat.ChatCompletionTool[] = [
     type: "function",
     function: {
       name: "get_professionals",
-      description: "Obtiene la lista de profesionales disponibles con los consultorios donde atienden y su localidad. Opcionalmente filtrada por consultorio y/o especialidad.",
+      description: "Obtiene la lista de profesionales disponibles con los consultorios donde atienden y su localidad. Filtrá por especialidad vos mismo usando el campo 'speciality' del resultado. Opcionalmente filtrá por consultorio con officeId.",
       parameters: {
         type: "object",
         properties: {
           officeId: {
             type: "number",
             description: "ID del consultorio para filtrar profesionales. Opcional.",
-          },
-          speciality: {
-            type: "string",
-            description: "Especialidad médica para filtrar (ej: 'Cardiología', 'Clínica General'). Opcional.",
           },
         },
         required: [],

--- a/backend/src/people/people.service.ts
+++ b/backend/src/people/people.service.ts
@@ -59,9 +59,8 @@ export class PeopleService {
     return em.findOne(Person, { email });
   }
 
-  async findProfessionalsWithOffices(officeId?: number, speciality?: string): Promise<any[]> {
+  async findProfessionalsWithOffices(officeId?: number): Promise<any[]> {
     const filter: any = { person: { type: "professional", active: true } };
-    if (speciality) filter.person.speciality = speciality;
     if (officeId) filter.room = { office: { idOffice: officeId } };
 
     const schedules = await em.find(Schedule, filter, {

--- a/backend/src/prompts/secretary.ts
+++ b/backend/src/prompts/secretary.ts
@@ -34,6 +34,8 @@ CAPACIDADES:
 REGLAS:
 - NO inventes información. Usá solo los datos provistos.
 - Sé directa y concisa. Evitá frases de relleno.
+- Respondé en UN SOLO mensaje. No dividas la respuesta en partes ni muestres tu razonamiento interno.
+- No expliques qué herramienta vas a usar ni qué estás haciendo. Simplemente respondé con el resultado.
 - Si el usuario no proporcionó todos los datos necesarios, preguntá antes de llamar a cualquier herramienta.
 - Si una herramienta falla, informá al usuario con un mensaje claro.
 - No respondas temas ajenos a turnos, profesionales y consultorios.


### PR DESCRIPTION
- DB speciality filter caused mismatches (e.g. "Urología" vs "Urólogo")
- Model now filters from returned data using exact DB values
- Prompt rules added to prevent multi-message reasoning leak